### PR TITLE
issues/4: Fix extension list failing to render on scroll  

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -174,7 +174,7 @@ div.pane-body>div>div>div>div.monaco-list-rows {
     border-radius: 0 0 var(--border-radius) var(--border-radius);
     width: 97% !important;
     padding-bottom: 0.5rem;
-    height: calc(100% - 1rem) !important;
+    /* height: calc(100% - 1rem) !important; */ /* Causes issues with scrollable lists */
 }
 
 li.action-item.icon {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -174,7 +174,8 @@ div.pane-body>div>div>div>div.monaco-list-rows {
     border-radius: 0 0 var(--border-radius) var(--border-radius);
     width: 97% !important;
     padding-bottom: 0.5rem;
-    /* height: calc(100% - 1rem) !important; */ /* Causes issues with scrollable lists */
+    /* Causes issues with scrollable lists */
+    /* height: calc(100% - 1rem) !important; */
 }
 
 li.action-item.icon {


### PR DESCRIPTION
The extensions list, both for installed extensions and in search results, fails to render elements that are not visible on the initial load. This results in only a portion of the extension list being accessible. For instance, some items are cut off, and a significant number of extensions do not appear at all, as the list does not update upon scrolling.

The issue appears to be related to the `height` property in the `styles.css` file for the `div.pane-body>div>div>div>div.monaco-list-rows` selector.

Modified CSS:

```css
div.pane-body>div>div>div>div.monaco-list-rows {
    border-radius: 0 0 var(--border-radius) var(--border-radius);
    width: 97% !important;
    padding-bottom: 0.5rem;
    /* Causes issues with scrollable lists */
    /* height: calc(100% - 1rem) !important; */
}
```

This change allows the list to render all its elements correctly, making all extensions accessible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll behavior for certain lists by updating related styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->