### PR TITLE
Fix issue #10 - PDFs do not appear in full

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -302,7 +302,7 @@ div .search-view .search-widget .replace-input {
 }
 
 div.monaco-workbench>div:has(iframe.webview.ready) {
-    height: calc(100% - 22.5rem) !important;
+    height: 100% !important;
 }
 
 .monaco-inputbox input::placeholder {


### PR DESCRIPTION
This PRs solve issue #10. It replaces in `styles.css` the following lines:
```css
div.monaco-workbench>div:has(iframe.webview.ready) {
    height: calc(100% - 22.5rem) !important;
}
```
by
```css
div.monaco-workbench>div:has(iframe.webview.ready) {
    height: 100% !important;
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the vertical sizing behavior of a container within the editor interface to occupy full available height, refining layout consistency and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->